### PR TITLE
Add cron job to backup cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Role Variables
 
  * `spinnaker_install`: Boolean. Defaults to true. Should spinnaker be
    installed? If using the spinnaker AMI, you probably want to disable this.
+ * `spinnaker_backup`: Boolean. Defaults to false. Should a cron job be added
+   to backup cassandra? Setting this true requires that you define
+   `spinnaker_backup_bucket`.
+ * `spinnaker_backup_bucket`: String. The S3 bucket to store cassandra backups.
+   Include a trailing slash if using folder names.
  * `spinnaker_cassandra_local`: Boolean. Defaults to true. Will cassandra run
    locally?
  * `spinnaker_cassandra_version`: String. Defaults to "2.1.11"
@@ -56,6 +61,8 @@ Example Playbooks
   roles:
     - AMeng.spinnaker
   vars:
+    spinnaker_backup: True
+    spinnaker_backup_bucket: "MyBucket"
     spinnaker_config:
       providers:
         aws:
@@ -70,6 +77,8 @@ Example Playbooks
   roles:
     - AMeng.spinnaker
   vars:
+    spinnaker_backup: True
+    spinnaker_backup_bucket: "MyBucket/MyFolder/"
     spinnaker_config:
       providers:
         aws:
@@ -97,6 +106,13 @@ Example Playbooks
         keyStorePassword: password
         keyStoreAliasName: okta
 ```
+
+Notes
+-----
+
+This playbook is only tested with AWS. While spinnaker supports other clouds,
+this playbook has not been tested with them. Contributions for other providers
+will be gladly accepted.
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
-spinnaker_install: true
-spinnaker_cassandra_local: true
+spinnaker_install: True
+spinnaker_backup: False
+spinnaker_backup_bucket: ""
+spinnaker_cassandra_local: True
 spinnaker_cassandra_version: 2.1.11
-spinnaker_redis_local: true
+spinnaker_redis_local: True
 spinnaker_packer_version: 0.8.6
 
 # Override these configuration variables to populate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,3 +33,7 @@
     - igor
     - orca
     - rush
+
+- name: Add cron job to backup cassandra
+  cron: name="spinnaker cassandra backup" special_time="daily" job='su - root -c "/opt/spinnaker/pylib/spinnaker/import_export.py --cloud aws --bucket {{ spinnaker_backup_bucket }} --mode export"'
+  when: spinnaker_backup == True


### PR DESCRIPTION
Add option for creating a cron job to backup cassandra to S3. This is disabled by default.
